### PR TITLE
Bump up Go to 1.16

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       with:
         go-version: 1.x
     - name: Install gocode
-      run: go get github.com/mdempsky/gocode
+      run: go install github.com/mdempsky/gocode@latest
     - name: Build
       run: make build
     - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6-alpine3.12
+FROM golang:1.16.6-alpine3.14
 
 RUN apk add --no-cache git make
 WORKDIR /go/src/github.com/x-motemen/gore/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /go/src/github.com/x-motemen/gore/
 COPY . .
 RUN make install
 
-RUN go get -u github.com/mdempsky/gocode   # for code completion
+RUN go install github.com/mdempsky/gocode@latest   # for code completion
 
 ENTRYPOINT ["gore"]

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ show-version: $(GOBIN)/gobump
 	@gobump show -r $(VERSION_PATH)
 
 $(GOBIN)/gobump:
-	@cd && go get github.com/x-motemen/gobump/cmd/gobump
+	@go install github.com/x-motemen/gobump/cmd/gobump@latest
 
 .PHONY: test
 test: build
@@ -33,7 +33,7 @@ lint: $(GOBIN)/golint
 	golint -set_exit_status ./...
 
 $(GOBIN)/golint:
-	cd && go get golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Only the latest major version.
 The gore command requires Go tool-chains on runtime, so standalone binary is not distributed.
 
 ```sh
-go get github.com/x-motemen/gore/cmd/gore
+go install github.com/x-motemen/gore/cmd/gore@latest
 ```
 
 Make sure `$GOPATH/bin` is in your `$PATH`.
@@ -55,7 +55,7 @@ Make sure `$GOPATH/bin` is in your `$PATH`.
 Also recommended:
 
 ```sh
-go get github.com/mdempsky/gocode   # for code completion
+go install github.com/mdempsky/gocode@latest   # for code completion
 ```
 
 Or you can use Docker:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/x-motemen/gore
 
-go 1.15
+go 1.16
 
 require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect


### PR DESCRIPTION
Since 1.17 is about to be released, we now require 1.16 as the minimum version support.