### PR TITLE
Switch from golint to staticcheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ test: build
 	go test -v ./...
 
 .PHONY: lint
-lint: $(GOBIN)/golint
+lint: $(GOBIN)/staticcheck
 	go vet ./...
-	golint -set_exit_status ./...
+	staticcheck ./...
 
-$(GOBIN)/golint:
-	go install golang.org/x/lint/golint@latest
+$(GOBIN)/staticcheck:
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 .PHONY: clean
 clean:

--- a/complete.go
+++ b/complete.go
@@ -51,7 +51,7 @@ func (s *Session) completeWord(line string, pos int) (string, []string, string) 
 		return "", nil, ""
 	}
 
-	if gocode.Available() == false {
+	if !gocode.Available() {
 		return "", nil, ""
 	}
 

--- a/quickfix.go
+++ b/quickfix.go
@@ -223,7 +223,7 @@ func (s *Session) isPureExpr(expr ast.Expr) bool {
 	case *ast.CallExpr:
 		tv := s.typeInfo.Types[expr.Fun]
 		for _, arg := range expr.Args {
-			if s.isPureExpr(arg) == false {
+			if !s.isPureExpr(arg) {
 				return false
 			}
 		}

--- a/session_gomod_test.go
+++ b/session_gomod_test.go
@@ -19,12 +19,6 @@ func chdir(dir string) func() {
 	return func() { os.Chdir(d) }
 }
 
-func setenv(name, value string) func() {
-	v := os.Getenv(name)
-	os.Setenv(name, value)
-	return func() { os.Setenv(name, v) }
-}
-
 func gomodSetup(t *testing.T) func() {
 	tempDir, err := ioutil.TempDir("", "gore-")
 	require.NoError(t, err)


### PR DESCRIPTION
Due to golint deprecation, we now switch to staticcheck.